### PR TITLE
Make capacity clearer

### DIFF
--- a/views/connections.html.twig
+++ b/views/connections.html.twig
@@ -258,7 +258,7 @@
                                     {% endif %}
                                     <br/>
                                     {% if connection.capacity2nd > 0 %}
-                                        <span class="muted" title="Capacity 2nd class">
+                                        <span class="muted" title="Expected occupancy 2nd class">
                                             {%- for i in [0, 1, 2] -%}
                                                 {%- if i < connection.capacity2nd -%}
                                                     ●


### PR DESCRIPTION
A high capacity would mean there's a lot of space, when in fact there a high number means little space. Not perfectly happy about the wording, but it's clearer that a high number is bad.
